### PR TITLE
주소록 단건 조회 실패, 리스트 조회

### DIFF
--- a/src/main/java/tdd/tddproject/domain/entity/user/Address.java
+++ b/src/main/java/tdd/tddproject/domain/entity/user/Address.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import tdd.tddproject.vo.user.AddressParam;
 
 import javax.persistence.*;
 
@@ -21,8 +24,9 @@ import javax.persistence.*;
  */
 @Entity @Getter
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
-@DynamicUpdate
-@DynamicInsert
+//@DynamicUpdate
+//@DynamicInsert
+//https://velog.io/@recordsbeat/DynamicUpdate%EA%B0%80-%EC%99%B8%EC%95%8A%EB%90%82%EB%8D%B0
 public class Address {
 
     @Id @Column(name = "ADDRESS_ID")
@@ -56,5 +60,26 @@ public class Address {
         this.addressStreet = addressStreet;
         this.addressReceiver = addressReceiver;
         this.addressPhone = addressPhone;
+    }
+
+    public void update(AddressParam param){
+        if (StringUtils.hasText(param.getAddressStreet())){
+            this.addressStreet = param.getAddressStreet();
+        }
+        if (StringUtils.hasText(param.getAddressZip())){
+            this.addressZip = param.getAddressZip();
+        }
+        if (StringUtils.hasText(param.getAddressCity())){
+            this.addressCity = param.getAddressCity();
+        }
+        if (StringUtils.hasText(param.getAddressReceiver())){
+            this.addressReceiver = param.getAddressReceiver();
+        }
+        if (StringUtils.hasText(param.getAddressPhone())){
+            this.addressPhone = param.getAddressPhone();
+        }
+
+
+
     }
 }

--- a/src/main/java/tdd/tddproject/global/exception/IdNotFoundException.java
+++ b/src/main/java/tdd/tddproject/global/exception/IdNotFoundException.java
@@ -1,0 +1,14 @@
+package tdd.tddproject.global.exception;
+
+import org.springframework.http.HttpStatus;
+import tdd.tddproject.global.exception.support.ExceptionSupport;
+
+public class IdNotFoundException extends ExceptionSupport {
+
+    // REST 에선 URI 가 자원이기 때문에 경로가 곧 자원이다.
+    // 출처: https://sanghaklee.tistory.com/61 [이상학의 개발블로그]
+    // 404 사용
+    public IdNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, 404, message);
+    }
+}

--- a/src/main/java/tdd/tddproject/global/exception/IdNotFoundException.java
+++ b/src/main/java/tdd/tddproject/global/exception/IdNotFoundException.java
@@ -11,4 +11,7 @@ public class IdNotFoundException extends ExceptionSupport {
     public IdNotFoundException(String message) {
         super(HttpStatus.NOT_FOUND, 404, message);
     }
+    public IdNotFoundException() {
+        super(HttpStatus.NOT_FOUND, 404, "해당 PK id를 찾을 수 없습니다");
+    }
 }

--- a/src/main/java/tdd/tddproject/global/exception/support/ExceptionResponseSupport.java
+++ b/src/main/java/tdd/tddproject/global/exception/support/ExceptionResponseSupport.java
@@ -1,0 +1,16 @@
+package tdd.tddproject.global.exception.support;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponseSupport {
+    private Integer errorCode;
+    private String message;
+
+    @Builder
+    public ExceptionResponseSupport(Integer errorCode, String message){
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/tdd/tddproject/global/exception/support/ExceptionSupport.java
+++ b/src/main/java/tdd/tddproject/global/exception/support/ExceptionSupport.java
@@ -1,0 +1,18 @@
+package tdd.tddproject.global.exception.support;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ExceptionSupport extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+    private final Integer errorCode;
+    private final String message;
+
+    public ExceptionSupport(HttpStatus httpStatus, Integer errorCode, String message){
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/tdd/tddproject/global/exception/support/GlobalExceptionHandler.java
+++ b/src/main/java/tdd/tddproject/global/exception/support/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package tdd.tddproject.global.exception.support;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ExceptionSupport.class)
+    public ResponseEntity<?> handler(ExceptionSupport e){
+        ExceptionResponseSupport response = ExceptionResponseSupport.builder()
+                .message(e.getMessage())
+                .errorCode(e.getErrorCode())
+                .build();
+
+        return new ResponseEntity<>(response, e.getHttpStatus());
+    }
+}

--- a/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
+++ b/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
@@ -2,10 +2,9 @@ package tdd.tddproject.hyechan.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import tdd.tddproject.hyechan.service.AddressService;
+import tdd.tddproject.vo.user.AddressParam;
 
 import static tdd.tddproject.global.util.Util.getMap;
 
@@ -25,5 +24,11 @@ public class AddressController {
     public ResponseEntity<?> getList(){
         return ResponseEntity.ok()
                 .body(getMap(addressService.getList()));
+    }
+
+    @PostMapping("/address")
+    public ResponseEntity<?> add(@RequestBody AddressParam addressParam){
+        return ResponseEntity.ok()
+                .body(getMap(addressService.add(addressParam)));
     }
 }

--- a/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
+++ b/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
@@ -20,4 +20,10 @@ public class AddressController {
         return ResponseEntity.ok()
                 .body(getMap(addressService.getById(id)));
     }
+
+    @GetMapping("/address")
+    public ResponseEntity<?> getList(){
+        return ResponseEntity.ok()
+                .body(getMap(addressService.getList()));
+    }
 }

--- a/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
+++ b/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
@@ -2,9 +2,13 @@ package tdd.tddproject.hyechan.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import tdd.tddproject.hyechan.service.AddressService;
 import tdd.tddproject.vo.user.AddressParam;
+
+import javax.validation.Valid;
 
 import static tdd.tddproject.global.util.Util.getMap;
 
@@ -27,7 +31,10 @@ public class AddressController {
     }
 
     @PostMapping("/address")
-    public ResponseEntity<?> add(@RequestBody AddressParam addressParam){
+    public ResponseEntity<?> add(@Valid @RequestBody AddressParam addressParam, BindingResult bindingResult) throws BindException {
+        if(bindingResult.hasErrors()){
+            throw new BindException(bindingResult);
+        }
         return ResponseEntity.ok()
                 .body(getMap(addressService.add(addressParam)));
     }

--- a/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
+++ b/src/main/java/tdd/tddproject/hyechan/controller/AddressController.java
@@ -38,4 +38,10 @@ public class AddressController {
         return ResponseEntity.ok()
                 .body(getMap(addressService.add(addressParam)));
     }
+
+    @PutMapping("/address/{id}")
+    public ResponseEntity<?> update(@RequestBody AddressParam addressParam, @PathVariable Long id){
+        addressService.update(addressParam, id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
+++ b/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
@@ -13,6 +13,8 @@ import tdd.tddproject.hyechan.mapper.AddressMapper;
 import tdd.tddproject.hyechan.mapper.UserMapper;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 
+import java.util.List;
+
 @Service
 @Transactional(rollbackFor = {Exception.class}, propagation = Propagation.REQUIRED)
 @RequiredArgsConstructor
@@ -27,5 +29,10 @@ public class AddressService {
         Address address = addressRepository.findById(id)
                 .orElseThrow(() -> new IdNotFoundException("해당 주소가 존재하지 않습니다."));
         return mapper.toDto(address);
+    }
+
+    public List<AddressDto> getList() {
+        List<Address> list = addressRepository.findAll();
+        return mapper.toDtoList(list);
     }
 }

--- a/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
+++ b/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
@@ -3,9 +3,10 @@ package tdd.tddproject.hyechan.service;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.factory.Mappers;
 import org.springframework.stereotype.Service;
-기import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import tdd.tddproject.domain.entity.user.Address;
+import tdd.tddproject.global.exception.IdNotFoundException;
 import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.dto.UserDto;
 import tdd.tddproject.hyechan.mapper.AddressMapper;
@@ -24,7 +25,7 @@ public class AddressService {
     public AddressDto getById(Long id){
 
         Address address = addressRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주소가 존재하지 않습니다."));
+                .orElseThrow(() -> new IdNotFoundException("해당 주소가 존재하지 않습니다."));
         return mapper.toDto(address);
     }
 }

--- a/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
+++ b/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
@@ -12,6 +12,7 @@ import tdd.tddproject.hyechan.dto.UserDto;
 import tdd.tddproject.hyechan.mapper.AddressMapper;
 import tdd.tddproject.hyechan.mapper.UserMapper;
 import tdd.tddproject.hyechan.repository.AddressRepository;
+import tdd.tddproject.vo.user.AddressParam;
 
 import java.util.List;
 
@@ -34,5 +35,10 @@ public class AddressService {
     public List<AddressDto> getList() {
         List<Address> list = addressRepository.findAll();
         return mapper.toDtoList(list);
+    }
+
+    public AddressDto add(AddressParam addressParam) {
+        Address address = mapper.toEntity(addressParam);
+        return mapper.toDto(addressRepository.save(address));
     }
 }

--- a/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
+++ b/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
@@ -14,7 +14,10 @@ import tdd.tddproject.hyechan.mapper.UserMapper;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.vo.user.AddressParam;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(rollbackFor = {Exception.class}, propagation = Propagation.REQUIRED)
@@ -24,6 +27,8 @@ public class AddressService {
     private final AddressRepository addressRepository;
     private final AddressMapper mapper = Mappers.getMapper(AddressMapper.class);
 
+    @PersistenceContext
+    EntityManager em;
 
     public AddressDto getById(Long id){
 
@@ -40,5 +45,11 @@ public class AddressService {
     public AddressDto add(AddressParam addressParam) {
         Address address = mapper.toEntity(addressParam);
         return mapper.toDto(addressRepository.save(address));
+    }
+
+    public void update(AddressParam updateParam, Long id) {
+        Address address = addressRepository.findById(id)
+                .orElseThrow(() -> new IdNotFoundException("해당 주소가 존재하지 않습니다"));
+        address.update(updateParam);
     }
 }

--- a/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
+++ b/src/main/java/tdd/tddproject/hyechan/service/AddressService.java
@@ -3,6 +3,8 @@ package tdd.tddproject.hyechan.service;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.factory.Mappers;
 import org.springframework.stereotype.Service;
+기import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.dto.UserDto;
@@ -11,6 +13,7 @@ import tdd.tddproject.hyechan.mapper.UserMapper;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 
 @Service
+@Transactional(rollbackFor = {Exception.class}, propagation = Propagation.REQUIRED)
 @RequiredArgsConstructor
 public class AddressService {
 

--- a/src/main/java/tdd/tddproject/vo/user/AddressParam.java
+++ b/src/main/java/tdd/tddproject/vo/user/AddressParam.java
@@ -8,15 +8,27 @@ import lombok.extern.slf4j.Slf4j;
 import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.domain.entity.user.User;
 
+import javax.validation.constraints.NotNull;
+
 @Slf4j
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class AddressParam {
+
+    @NotNull
     private String addressZip;
+
+    @NotNull
     private String addressCity;
+
+    @NotNull
     private String addressStreet;
+
+    @NotNull
     private String addressReceiver;
+
+    @NotNull
     private String addressPhone;
 
     public Address toEntity(){

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.hyechan.util.AddressConstructor;
+import tdd.tddproject.vo.user.AddressParam;
 
 import javax.persistence.EntityManager;
 
@@ -25,6 +27,8 @@ import java.util.ArrayList;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -108,8 +112,39 @@ public class AddressTest extends AddressConstructor {
         //then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result", Matchers.hasSize(3)))
-                .andExpect(jsonPath("$.result.[1].addressCity").value(ADDRESS_CITY+1))
-                .andExpect(jsonPath("$.result.[2].addressReceiver").value(ADDRESS_RECEIVER+2))
-                .andExpect(jsonPath("$.result.[3].addressPhone").value(ADDRESS_PHONE.substring(0,ADDRESS_PHONE.length() -1)+3));
+                .andExpect(jsonPath("$.result.[0].addressCity").value(ADDRESS_CITY+0))
+                .andExpect(jsonPath("$.result.[1].addressReceiver").value(ADDRESS_RECEIVER+1))
+                .andExpect(jsonPath("$.result.[2].addressPhone").value(ADDRESS_PHONE.substring(0,ADDRESS_PHONE.length() -1)+2))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+
+    // @author: hyechan, @since: 2022/05/05 10:41 오전
+    @Test
+    void 주소록_추가() throws Exception{
+        //given
+        AddressParam param = createParam();
+        //when
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/address")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(toJson(param))
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.addressPhone").value(ADDRESS_PHONE))
+                .andExpect(jsonPath("$.result.addressCity").value(ADDRESS_CITY))
+                .andExpect(jsonPath("$.result.addressStreet").value(ADDRESS_STREET))
+                .andExpect(jsonPath("$.result.addressReceiver").value(ADDRESS_RECEIVER))
+                .andExpect(jsonPath("$.result.addressZip").value(ADDRESS_ZIP))
+                .andDo(MockMvcResultHandlers.print())
+                .andDo(document("address/address_add",
+                        requestFields(
+                            fieldWithPath("addressPhone").type(JsonFieldType.STRING).description("폰번호"),
+                            fieldWithPath("addressCity").type(JsonFieldType.STRING).description("시군구"),
+                            fieldWithPath("addressStreet").type(JsonFieldType.STRING).description("도로명"),
+                            fieldWithPath("addressReceiver").type(JsonFieldType.STRING).description("받는사람"),
+                            fieldWithPath("addressZip").type(JsonFieldType.STRING).description("우편번호")
+                        )
+                ));
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -43,10 +43,11 @@ public class AddressTest extends AddressConstructor {
     @Autowired
     private AddressRepository addressRepository;
 
-
+    Long id;
 
     @BeforeEach
     public void init(){
+        id = 1L;
         entityManager.createNativeQuery("ALTER SEQUENCE HIBERNATE_SEQUENCE RESTART WITH 1 ").executeUpdate();
     }
 
@@ -55,7 +56,6 @@ public class AddressTest extends AddressConstructor {
     @Test
     void 주소록_단건_조회_성공() throws Exception{
         //given
-        Long id = 1L;
         Address address = createEntity(createParam());
         addressRepository.save(address);
         //when

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -161,7 +161,24 @@ public class AddressTest extends AddressConstructor {
                 .content(toJson(param))
                 .accept(MediaType.APPLICATION_JSON_VALUE));
         //then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+                    .andDo(MockMvcResultHandlers.print());
+    }
 
+
+    // @author: hyechan, @since: 2022/05/05 11:34 오전
+    @Test
+    void 주소록_업데이트() throws Exception{
+        //given
+        addressRepository.save(createEntity(createParam()));
+        AddressParam updateParam = updateParam();
+        //when
+        mockMvc.perform(RestDocumentationRequestBuilders.put("/address/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(toJson(updateParam)))
+        //then
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -44,10 +44,12 @@ public class AddressTest extends AddressConstructor {
     private AddressRepository addressRepository;
 
     Long id;
+    Long failId;
 
     @BeforeEach
     public void init(){
         id = 1L;
+        failId = 1000L;
         entityManager.createNativeQuery("ALTER SEQUENCE HIBERNATE_SEQUENCE RESTART WITH 1 ").executeUpdate();
     }
 
@@ -78,4 +80,17 @@ public class AddressTest extends AddressConstructor {
 
     }
 
+
+    // @author: hyechan, @since: 2022/05/04 9:15 오후
+    @Test
+    void 주소록_단건_조회_실패() throws Exception{
+        //given
+        addressRepository.save(createEntity(createParam()));
+        //when
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/address/{id}", failId)
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        //then
+                .andExpect(status().isNotFound())
+                .andDo(MockMvcResultHandlers.print());
+    }
 }

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -1,5 +1,6 @@
 package tdd.tddproject.hyechan.Integration;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +20,8 @@ import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 
 import javax.persistence.EntityManager;
+
+import java.util.ArrayList;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -92,5 +95,21 @@ public class AddressTest extends AddressConstructor {
         //then
                 .andExpect(status().isNotFound())
                 .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    void 주소록_리스트_조회() throws Exception{
+        //given
+        ArrayList<Address> list = createEntity(createParam(3));
+        addressRepository.saveAll(list);
+        //when
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/address")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", Matchers.hasSize(3)))
+                .andExpect(jsonPath("$.result.[1].addressCity").value(ADDRESS_CITY+1))
+                .andExpect(jsonPath("$.result.[2].addressReceiver").value(ADDRESS_RECEIVER+2))
+                .andExpect(jsonPath("$.result.[3].addressPhone").value(ADDRESS_PHONE.substring(0,ADDRESS_PHONE.length() -1)+3));
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/Integration/AddressTest.java
@@ -147,4 +147,21 @@ public class AddressTest extends AddressConstructor {
                         )
                 ));
     }
+
+
+    // @author: hyechan, @since: 2022/05/05 11:22 오전
+    @Test
+    void 주소록_추가_받는사람null_실패_() throws Exception{
+        //given
+        AddressParam param = createParam();
+        param.setAddressReceiver(null);
+        //when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/address")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(toJson(param))
+                .accept(MediaType.APPLICATION_JSON_VALUE));
+        //then
+        resultActions.andExpect(status().isBadRequest());
+
+    }
 }

--- a/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
@@ -124,4 +124,24 @@ public class AddressControllerUnitTest extends AddressConstructor {
                 .andExpect(jsonPath("$.result.addressZip").value(ADDRESS_ZIP))
                 .andDo(MockMvcResultHandlers.print());
     }
+
+    @Test
+    void 주소록_업데이트() throws Exception{
+        //given
+        AddressDto dto = mapper.toDto(createEntity(createParam()));
+        AddressParam updateParam = updateParam();
+        dto.setAddressPhone(updateParam.getAddressPhone());
+        dto.setAddressReceiver(updateParam.getAddressReceiver());
+        dto.setAddressStreet(updateParam.getAddressStreet());
+
+        willDoNothing().given(addressService).update(updateParam, id);
+        //when
+        mockMvc.perform(RestDocumentationRequestBuilders.put("/address/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .content(toJson(updateParam)))
+                //then
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
+    }
 }

--- a/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
@@ -1,5 +1,6 @@
 package tdd.tddproject.hyechan.controller;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.hyechan.mapper.AddressMapper;
@@ -15,7 +17,6 @@ import tdd.tddproject.hyechan.service.AddressService;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,15 +31,21 @@ public class AddressControllerUnitTest extends AddressConstructor {
 
     AddressMapper mapper = Mappers.getMapper(AddressMapper.class);
 
+    Long id;
+
+    @BeforeEach
+    public void init() {
+        id = 1L;
+    }
+
     // @author: hyechan, @since: 2022/04/30 3:40 오후
     @Test
     void 주소록_단건_조회_성공() throws Exception{
         //given
-        Long id = 1L;
         Address address = createEntity(createParam());
         given(addressService.getById(id)).willReturn(mapper.toDto(address));
         //when
-        ResultActions resultActions = mockMvc.perform(get("/address/{id}", id)
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/address/{id}", id)
                 .accept(MediaType.APPLICATION_JSON_VALUE));
         //then
         resultActions

--- a/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
@@ -21,6 +21,7 @@ import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.mapper.AddressMapper;
 import tdd.tddproject.hyechan.service.AddressService;
 import tdd.tddproject.hyechan.util.AddressConstructor;
+import tdd.tddproject.vo.user.AddressParam;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -100,5 +101,27 @@ public class AddressControllerUnitTest extends AddressConstructor {
                 .andExpect(jsonPath("$.result.[0].addressCity").value(ADDRESS_CITY+0))
                 .andExpect(jsonPath("$.result.[1].addressReceiver").value(ADDRESS_RECEIVER+1))
                 .andExpect(jsonPath("$.result.[2].addressPhone").value(ADDRESS_PHONE.substring(0,ADDRESS_PHONE.length() -1)+2));
+    }
+
+
+    @Test
+    void 주소록_추가() throws Exception{
+        //given
+        AddressParam param = createParam();
+        AddressDto dto = mapper.toDto(createEntity(param));
+        given(addressService.add(param)).willReturn(dto);
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.post("/address")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(toJson(param))
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.addressPhone").value(ADDRESS_PHONE))
+                .andExpect(jsonPath("$.result.addressCity").value(ADDRESS_CITY))
+                .andExpect(jsonPath("$.result.addressStreet").value(ADDRESS_STREET))
+                .andExpect(jsonPath("$.result.addressReceiver").value(ADDRESS_RECEIVER))
+                .andExpect(jsonPath("$.result.addressZip").value(ADDRESS_ZIP))
+                .andDo(MockMvcResultHandlers.print());
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
@@ -1,5 +1,7 @@
 package tdd.tddproject.hyechan.controller;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -12,11 +14,17 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import tdd.tddproject.domain.entity.user.Address;
+import tdd.tddproject.global.exception.IdNotFoundException;
+import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.mapper.AddressMapper;
 import tdd.tddproject.hyechan.service.AddressService;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 
+import java.util.Optional;
+
+
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,10 +40,12 @@ public class AddressControllerUnitTest extends AddressConstructor {
     AddressMapper mapper = Mappers.getMapper(AddressMapper.class);
 
     Long id;
+    Long failId;
 
     @BeforeEach
     public void init() {
         id = 1L;
+        failId = 1000L;
     }
 
     // @author: hyechan, @since: 2022/04/30 3:40 오후
@@ -58,5 +68,18 @@ public class AddressControllerUnitTest extends AddressConstructor {
                 .andExpect(jsonPath("$.result.addressStreet").value(ADDRESS_STREET))
                 .andDo(MockMvcResultHandlers.print());
 
+    }
+
+    // @author: hyechan, @since: 2022/05/04 9:15 오후
+    @Test
+    void 주소록_단건_조회_실패() throws Exception{
+
+        given(addressService.getById(failId))
+                .willThrow(new IdNotFoundException("NotFound"+failId));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/address/{id}", failId)
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound())
+                .andDo(MockMvcResultHandlers.print());
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/controller/AddressControllerUnitTest.java
@@ -1,6 +1,7 @@
 package tdd.tddproject.hyechan.controller;
 
 import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -20,6 +22,7 @@ import tdd.tddproject.hyechan.mapper.AddressMapper;
 import tdd.tddproject.hyechan.service.AddressService;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 
@@ -81,5 +84,21 @@ public class AddressControllerUnitTest extends AddressConstructor {
                 .accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound())
                 .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    void 주소록_리스트_조회() throws Exception{
+        //given
+        ArrayList<Address> list = createEntity(createParam(3));
+        given(addressService.getList()).willReturn(mapper.toDtoList(list));
+
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/address")
+                .accept(MediaType.APPLICATION_JSON_VALUE));
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", Matchers.hasSize(3)))
+                .andExpect(jsonPath("$.result.[0].addressCity").value(ADDRESS_CITY+0))
+                .andExpect(jsonPath("$.result.[1].addressReceiver").value(ADDRESS_RECEIVER+1))
+                .andExpect(jsonPath("$.result.[2].addressPhone").value(ADDRESS_PHONE.substring(0,ADDRESS_PHONE.length() -1)+2));
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
@@ -41,4 +41,5 @@ public class AddressRepositoryUnitTest extends AddressConstructor {
         Assertions.assertEquals(address.getAddressReceiver(), ADDRESS_RECEIVER);
         Assertions.assertEquals(address.getAddressPhone(), ADDRESS_PHONE);
     }
+
 }

--- a/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import tdd.tddproject.domain.entity.user.Address;
+import tdd.tddproject.global.exception.IdNotFoundException;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 import tdd.tddproject.vo.user.AddressParam;
 
@@ -41,6 +42,26 @@ public class AddressRepositoryUnitTest extends AddressConstructor {
         Assertions.assertEquals(address.getAddressStreet(), ADDRESS_STREET);
         Assertions.assertEquals(address.getAddressReceiver(), ADDRESS_RECEIVER);
         Assertions.assertEquals(address.getAddressPhone(), ADDRESS_PHONE);
+    }
+
+
+    // @author: hyechan, @since: 2022/05/05 12:17 오후 // ? 검증
+    @Test
+    void 주소록_업데이트() throws Exception{
+        //given
+        Address entity = createEntity(createParam());
+        addressRepository.save(entity);
+        //when
+        Address address = addressRepository.findById(id)
+                .orElseThrow(() -> new IdNotFoundException("해당 주소가 존재하지 않습니다"));
+        address.update(updateParam());
+        //then
+        Assertions.assertEquals(address.getAddressId(), id);
+        Assertions.assertEquals(address.getAddressZip(), ADDRESS_ZIP);
+        Assertions.assertEquals(address.getAddressCity(), ADDRESS_CITY);
+        Assertions.assertEquals(address.getAddressStreet(), UPDATE_ADDRESS_STREET);
+        Assertions.assertEquals(address.getAddressReceiver(), UPDATE_ADDRESS_RECEIVER);
+        Assertions.assertEquals(address.getAddressPhone(), UPDATE_ADDRESS_PHONE);
     }
 
 }

--- a/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
@@ -1,6 +1,7 @@
 package tdd.tddproject.hyechan.repository;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -18,15 +19,22 @@ public class AddressRepositoryUnitTest extends AddressConstructor {
     @Autowired
     private AddressRepository addressRepository;
 
+    Long id;
+
+    @BeforeEach
+    public void init(){
+        id = 1L;
+    }
+
     @Test
     void 주소록_단건_조회_성공() throws Exception{
         //given
         addressRepository.save(createEntity(createParam()));
         //when
-        Address address = addressRepository.findById(1L)
+        Address address = addressRepository.findById(id)
                 .orElseThrow(RuntimeException::new);
         //then
-        Assertions.assertEquals(address.getAddressId(), 1L);
+        Assertions.assertEquals(address.getAddressId(), id);
         Assertions.assertEquals(address.getAddressZip(), ADDRESS_ZIP);
         Assertions.assertEquals(address.getAddressCity(), ADDRESS_CITY);
         Assertions.assertEquals(address.getAddressStreet(), ADDRESS_STREET);

--- a/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/repository/AddressRepositoryUnitTest.java
@@ -26,6 +26,7 @@ public class AddressRepositoryUnitTest extends AddressConstructor {
         id = 1L;
     }
 
+    // 테스트 주도방식이면 이 코드 짤 필요 없음
     @Test
     void 주소록_단건_조회_성공() throws Exception{
         //given

--- a/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
@@ -7,15 +7,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.global.exception.IdNotFoundException;
 import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.hyechan.util.AddressConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class) // springboot x, Mockito 따로 띄움
@@ -43,7 +47,7 @@ class AddressServiceUnitTest extends AddressConstructor {
         //when
         AddressDto dto = addressService.getById(id);
         //then
-        assertEquals(dto.getAddressId(), id);
+        assertThat(dto.getAddressId()).isEqualTo(id);
     }
 
     // @author: hyechan, @since: 2022/05/04 9:15 오후
@@ -60,4 +64,27 @@ class AddressServiceUnitTest extends AddressConstructor {
                 .isInstanceOf(IdNotFoundException.class);
     }
 
+
+    // @author: hyechan, @since: 2022/05/04 10:50 오후
+    @Test
+    void 주소록_리스트_조회() throws Exception{
+        //given
+        ArrayList<Address> list = createEntity(createParam(3));
+        given(addressRepository.findAll()).willReturn(list);
+        //when
+        List<AddressDto> dtoList = addressService.getList();
+        //then
+        assertThat(list.get(0).getAddressCity()).isEqualTo(dtoList.get(0).getAddressCity());
+        assertThat(dtoList).hasSize(list.size());
+        // --
+        assertThat(dtoList)
+                .extracting(AddressDto::getAddressCity)
+                .containsExactly(ADDRESS_CITY+0, ADDRESS_CITY+1, ADDRESS_CITY+2);
+//                .containsExactly(list.get(0).getAddressCity(), list.get(1).getAddressCity(), list.get(2).getAddressCity());
+        assertThat(dtoList)
+                .extracting(AddressDto::getAddressPhone,AddressDto::getAddressZip)
+                .contains(tuple("010-0000-0000","000000"))
+                .contains(tuple("010-0000-0001","000001"))
+                .contains(tuple("010-0000-0002","000002"));
+    }
 }

--- a/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
@@ -1,11 +1,13 @@
 package tdd.tddproject.hyechan.service;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tdd.tddproject.global.exception.IdNotFoundException;
 import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.hyechan.util.AddressConstructor;
@@ -26,10 +28,12 @@ class AddressServiceUnitTest extends AddressConstructor {
     AddressRepository addressRepository;
 
     Long id;
+    Long failId;
 
     @BeforeEach
     public void init(){
         id = 1L;
+        failId = 1000L;
     }
 
     @Test
@@ -40,6 +44,20 @@ class AddressServiceUnitTest extends AddressConstructor {
         AddressDto dto = addressService.getById(id);
         //then
         assertEquals(dto.getAddressId(), id);
+    }
+
+    // @author: hyechan, @since: 2022/05/04 9:15 오후
+    @Test
+    void 주소록_단건_조회_실패() throws Exception{
+        //given
+        given(addressRepository.findById(failId))
+                .willThrow(new IdNotFoundException());
+
+        Assertions.assertThatThrownBy(()->
+        //when
+                addressService.getById(failId))
+        //then
+                .isInstanceOf(IdNotFoundException.class);
     }
 
 }

--- a/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
@@ -1,5 +1,6 @@
 package tdd.tddproject.hyechan.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,14 +25,21 @@ class AddressServiceUnitTest extends AddressConstructor {
     @Mock
     AddressRepository addressRepository;
 
+    Long id;
+
+    @BeforeEach
+    public void init(){
+        id = 1L;
+    }
+
     @Test
     void 주소록_단건_조회_성공() throws Exception{
         //given
-        given(addressRepository.findById(1L)).willReturn(Optional.ofNullable(createEntity(createParam())));
+        given(addressRepository.findById(id)).willReturn(Optional.ofNullable(createEntity(createParam())));
         //when
-        AddressDto dto = addressService.getById(1L);
+        AddressDto dto = addressService.getById(id);
         //then
-        assertEquals(dto.getAddressId(), 1L);
+        assertEquals(dto.getAddressId(), id);
     }
 
 }

--- a/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class) // springboot x, Mockito 따로 띄움
 class AddressServiceUnitTest extends AddressConstructor {
@@ -106,6 +108,18 @@ class AddressServiceUnitTest extends AddressConstructor {
         assertThat(dto.getAddressZip()).isEqualTo(ADDRESS_ZIP);
         assertThat(dto.getAddressStreet()).isEqualTo(ADDRESS_STREET);
         assertThat(dto.getAddressReceiver()).isEqualTo(ADDRESS_RECEIVER);
+    }
 
+
+    // @author: hyechan, @since: 2022/05/05 11:51 오전
+    @Test
+    void 주소록_업데이트() throws Exception{
+        //given
+        Address entity = createEntity(createParam());
+        given(addressRepository.findById(id)).willReturn(Optional.ofNullable(entity));
+        //when
+        addressService.update(updateParam(), id);
+        //then
+        verify(addressRepository, times(1)).findById(id);
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
+++ b/src/test/java/tdd/tddproject/hyechan/service/AddressServiceUnitTest.java
@@ -12,6 +12,7 @@ import tdd.tddproject.global.exception.IdNotFoundException;
 import tdd.tddproject.hyechan.dto.AddressDto;
 import tdd.tddproject.hyechan.repository.AddressRepository;
 import tdd.tddproject.hyechan.util.AddressConstructor;
+import tdd.tddproject.vo.user.AddressParam;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.Optional;
 
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -86,5 +88,24 @@ class AddressServiceUnitTest extends AddressConstructor {
                 .contains(tuple("010-0000-0000","000000"))
                 .contains(tuple("010-0000-0001","000001"))
                 .contains(tuple("010-0000-0002","000002"));
+    }
+
+
+    // @author: hyechan, @since: 2022/05/05 10:46 오전
+    @Test
+    void 리스트_추가() throws Exception{
+        //given
+        AddressParam param = createParam();
+        Address entity = createEntity(param);
+        given(addressRepository.save(any())).willReturn(entity);
+        //when
+        AddressDto dto = addressService.add(param);
+        //then
+        assertThat(dto.getAddressCity()).isEqualTo(ADDRESS_CITY);
+        assertThat(dto.getAddressPhone()).isEqualTo(ADDRESS_PHONE);
+        assertThat(dto.getAddressZip()).isEqualTo(ADDRESS_ZIP);
+        assertThat(dto.getAddressStreet()).isEqualTo(ADDRESS_STREET);
+        assertThat(dto.getAddressReceiver()).isEqualTo(ADDRESS_RECEIVER);
+
     }
 }

--- a/src/test/java/tdd/tddproject/hyechan/util/AddressConstructor.java
+++ b/src/test/java/tdd/tddproject/hyechan/util/AddressConstructor.java
@@ -2,9 +2,11 @@ package tdd.tddproject.hyechan.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.platform.commons.util.StringUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 import tdd.tddproject.domain.entity.user.Address;
 import tdd.tddproject.vo.user.AddressParam;
+import tdd.tddproject.vo.user.UserParam;
 
 import java.util.ArrayList;
 
@@ -50,7 +52,17 @@ public class AddressConstructor implements ConstructorCreate<Address, AddressPar
 
     @Override
     public ArrayList<AddressParam> createParam(int count) {
-        return null;
+        ArrayList<AddressParam> arrayList = new ArrayList<>();
+        for(int i = 0; i < count; i ++){
+            AddressParam param = new AddressParam();
+            param.setAddressCity(ADDRESS_CITY+i);
+            param.setAddressReceiver(ADDRESS_RECEIVER+i);
+            param.setAddressPhone(ADDRESS_PHONE.substring(0, ADDRESS_PHONE.length() -1)+i);
+            param.setAddressStreet(ADDRESS_STREET+i);
+            param.setAddressZip(ADDRESS_ZIP.substring(0,ADDRESS_ZIP.length() -1)+i);
+            arrayList.add(param);
+        }
+        return arrayList;
     }
 
     @Override

--- a/src/test/java/tdd/tddproject/hyechan/util/AddressConstructor.java
+++ b/src/test/java/tdd/tddproject/hyechan/util/AddressConstructor.java
@@ -18,6 +18,10 @@ public class AddressConstructor implements ConstructorCreate<Address, AddressPar
     protected String ADDRESS_RECEIVER = "test";
     protected String ADDRESS_PHONE = "010-0000-0000";
 
+    protected String UPDATE_ADDRESS_PHONE = "999-9999-9999";
+    protected String UPDATE_ADDRESS_RECEIVER = "update";
+    protected String UPDATE_ADDRESS_STREET = "업데이트 501호";
+
     @Override
     public Address createEntity(AddressParam param) {
         Address address = param.toEntity();
@@ -67,7 +71,11 @@ public class AddressConstructor implements ConstructorCreate<Address, AddressPar
 
     @Override
     public AddressParam updateParam() {
-        return null;
+        AddressParam param = new AddressParam();
+        param.setAddressPhone(UPDATE_ADDRESS_PHONE);
+        param.setAddressReceiver(UPDATE_ADDRESS_RECEIVER);
+        param.setAddressStreet(UPDATE_ADDRESS_STREET);
+        return param;
     }
     @Override
     public String toJson(AddressParam param) throws JsonProcessingException {


### PR DESCRIPTION
[Test Refactor : Long id BeforeEach 로 값 주기]
[Test Fix : AddressService @transactional코드 누락]
은 지난 리뷰 참고하여 조금 수정했습니다
--
[Feat : Exception 처리 support 파일 추가]
[Feat : IdNotFoundException 파라미터 없는 생성자]
Exception 처리해주기 위해서 만들었습니다.
--
[Test Feat : 주소록_단건_조회_실패] : 주소록 단건 조회 실패 코드
[Feat : 주소록_리스트_조회 (테스트+프로덕션)] : 주소록 리스트 조회 프로덕선+테스트코드